### PR TITLE
Fix visibility sensor: guard null access, add unit conversion, displa…

### DIFF
--- a/dist/weather-chart-card-ha.js
+++ b/dist/weather-chart-card-ha.js
@@ -1298,7 +1298,6 @@ var WeatherChartCard = (function () {
       delete newConfig.sun_latitude;
       delete newConfig.sun_longitude;
       delete newConfig.sun_timezone;
-      delete newConfig.timezone;
       this._cityInput = '';
       this._geoStatus = '';
       this.configChanged(newConfig);
@@ -1436,6 +1435,7 @@ var WeatherChartCard = (function () {
       <div class="textfield-container">
 <label class="switch-label">Entity</label>
 <select
+  aria-label="Entity"
   style="width: 100%; padding: 8px; margin-bottom: 8px; border: 1px solid var(--divider-color, #ccc); border-radius: 4px; background: var(--card-background-color, #fff); color: var(--primary-text-color, #000); font-size: 14px;"
   .value=${this._entity}
   @change=${(e) => this._EntityChanged(e, 'entity')}
@@ -1452,6 +1452,7 @@ var WeatherChartCard = (function () {
       <div>
         <label>Select custom language</label>
         <select
+          aria-label="Select custom language"
           style="width: 100%; padding: 8px; margin: 10px 0; font-size: 14px; border: 1px solid var(--divider-color); border-radius: 4px; background: var(--card-background-color); color: var(--primary-text-color);"
           .value=${this._config.locale || ''}
           @change=${(e) => {
@@ -1953,6 +1954,7 @@ var WeatherChartCard = (function () {
           <div>
             <label>Precipitation Type (Probability if supported by the weather entity)</label>
             <select
+              aria-label="Precipitation Type"
               style="width: 100%; padding: 8px; margin: 10px 0; font-size: 14px; border: 1px solid var(--divider-color); border-radius: 4px; background: var(--card-background-color); color: var(--primary-text-color);"
               .value=${forecastConfig.precipitation_type || 'rainfall'}
               @change=${(e) => {
@@ -2017,6 +2019,7 @@ var WeatherChartCard = (function () {
                 <span class="experimental-badge" ?hidden=${(forecastConfig.gradient_mode || 'classic') !== 'adaptive'}>Experimental</span>
               </div>
               <select
+                aria-label="Temperature Gradient Mode"
                 style="width: 100%; padding: 8px; margin: 10px 0; font-size: 14px; border: 1px solid var(--divider-color); border-radius: 4px; background: var(--card-background-color); color: var(--primary-text-color);"
                 .value=${forecastConfig.gradient_mode || 'classic'}
                 @change=${(e) => {
@@ -2032,6 +2035,7 @@ var WeatherChartCard = (function () {
             <div ?hidden=${(forecastConfig.gradient_mode || 'classic') === 'classic'}>
               <label>Climate Preset Range</label>
               <select
+                aria-label="Climate Preset Range"
                 style="width: 100%; padding: 8px; margin: 10px 0; font-size: 14px; border: 1px solid var(--divider-color); border-radius: 4px; background: var(--card-background-color); color: var(--primary-text-color);"
                 .value=${forecastConfig.gradient_preset || 'temperate'}
                 @change=${(e) => {
@@ -2058,6 +2062,7 @@ var WeatherChartCard = (function () {
             <div>
               <label>Convert temperature to</label>
               <select
+                aria-label="Convert temperature to"
                 style="width: 100%; padding: 8px; margin: 10px 0; font-size: 14px; border: 1px solid var(--divider-color); border-radius: 4px; background: var(--card-background-color); color: var(--primary-text-color);"
                 .value=${unitsConfig.temperature || ''}
                 @change=${(e) => {
@@ -2073,6 +2078,7 @@ var WeatherChartCard = (function () {
             <div>
               <label>Convert pressure to</label>
               <select
+                aria-label="Convert pressure to"
                 style="width: 100%; padding: 8px; margin: 10px 0; font-size: 14px; border: 1px solid var(--divider-color); border-radius: 4px; background: var(--card-background-color); color: var(--primary-text-color);"
                 .value=${unitsConfig.pressure || ''}
                 @change=${(e) => {
@@ -2089,6 +2095,7 @@ var WeatherChartCard = (function () {
             <div>
               <label>Convert wind speed to</label>
               <select
+                aria-label="Convert wind speed to"
                 style="width: 100%; padding: 8px; margin: 10px 0; font-size: 14px; border: 1px solid var(--divider-color); border-radius: 4px; background: var(--card-background-color); color: var(--primary-text-color);"
                 .value=${unitsConfig.speed || ''}
                 @change=${(e) => {
@@ -2107,6 +2114,7 @@ var WeatherChartCard = (function () {
             <div>
               <label>Display precipitation unit</label>
               <select
+                aria-label="Display precipitation unit"
                 style="width: 100%; padding: 8px; margin: 10px 0; font-size: 14px; border: 1px solid var(--divider-color); border-radius: 4px; background: var(--card-background-color); color: var(--primary-text-color);"
                 .value=${unitsConfig.precipitation || ''}
                 @change=${(e) => {
@@ -18614,7 +18622,13 @@ var WeatherChartCard = (function () {
       this.windSpeed = this.config.windspeed ? hass.states[this.config.windspeed].state : this.weather.attributes.wind_speed;
       this.dew_point = this.config.dew_point ? hass.states[this.config.dew_point].state : this.weather.attributes.dew_point;
       this.wind_gust_speed = this.config.wind_gust_speed ? hass.states[this.config.wind_gust_speed].state : this.weather.attributes.wind_gust_speed;
-      this.visibility = this.config.visibility ? hass.states[this.config.visibility].state : this.weather.attributes.visibility;
+      if (this.config.visibility && hass.states[this.config.visibility]) {
+        this.visibility = hass.states[this.config.visibility].state;
+        this.visibilitySourceUnit = hass.states[this.config.visibility].attributes.unit_of_measurement || this.weather.attributes.visibility_unit;
+      } else {
+        this.visibility = this.weather.attributes.visibility;
+        this.visibilitySourceUnit = this.weather.attributes.visibility_unit;
+      }
 
       if (this.config.winddir && hass.states[this.config.winddir] && hass.states[this.config.winddir].state !== undefined) {
         this.windDirection = parseFloat(hass.states[this.config.winddir].state);
@@ -18702,6 +18716,13 @@ var WeatherChartCard = (function () {
       return (this.weather.attributes.supported_features & feature) !== 0;
     }
 
+    get _canAutoRotate() {
+      const interval = this.config && this.config.forecast ? parseInt(this.config.forecast.auto_rotate, 10) : 0;
+      return interval > 0 && this.weather
+        && this.supportsFeature(WeatherEntityFeature.FORECAST_DAILY)
+        && this.supportsFeature(WeatherEntityFeature.FORECAST_HOURLY);
+    }
+
     constructor() {
       super();
       this.resizeObserver = null;
@@ -18720,6 +18741,8 @@ var WeatherChartCard = (function () {
       this.stopAutoRotate();
       const interval = this.config && this.config.forecast ? parseInt(this.config.forecast.auto_rotate, 10) : 0;
       if (!interval || interval < 1 || interval > 60) return;
+      // Only rotate if the entity supports both daily and hourly forecasts
+      if (!this.weather || !this.supportsFeature(WeatherEntityFeature.FORECAST_DAILY) || !this.supportsFeature(WeatherEntityFeature.FORECAST_HOURLY)) return;
       // Align to the next whole minute, then start the interval
       const now = new Date();
       const msUntilNextMinute = (60 - now.getSeconds()) * 1000 - now.getMilliseconds();
@@ -19327,6 +19350,26 @@ var WeatherChartCard = (function () {
     }
 
     return numericValue * fromFactor / toFactor;
+  }
+
+  convertVisibility(value, fromUnit, toUnit) {
+    const numericValue = Number(value);
+    if (!Number.isFinite(numericValue)) {
+      return value;
+    }
+    if (!fromUnit || !toUnit || fromUnit === toUnit) {
+      return numericValue;
+    }
+    // Normalize to meters first
+    const toMeters = { 'm': 1, 'km': 1000, 'mi': 1609.344, 'yd': 0.9144, 'ft': 0.3048 };
+    const fromFactor = toMeters[fromUnit];
+    const toFactor = toMeters[toUnit];
+    if (!fromFactor || !toFactor) {
+      return numericValue;
+    }
+    const result = numericValue * fromFactor / toFactor;
+    // Round to 1 decimal if needed, whole number if >= 10
+    return result >= 10 ? Math.round(result) : Math.round(result * 10) / 10;
   }
 
   async firstUpdated(changedProperties) {
@@ -20302,16 +20345,44 @@ var WeatherChartCard = (function () {
     const showDate = this.config.show_date;
     const currentDate = new Date();
     
-    // Force timezone conversion using explicit formatters
-    const timeFormatter = new Intl.DateTimeFormat(this.config.locale || 'en-US', {
-      hour: showHourLeadingZero ? '2-digit' : 'numeric',
+    // Get hour in the correct timezone
+    const hourIn24 = parseInt(new Intl.DateTimeFormat('en-US', { hour: 'numeric', hour12: false, timeZone: timezone }).format(currentDate));
+    const hourNum = use12HourFormat ? (hourIn24 % 12 || 12) : hourIn24;
+    let hourStr = String(hourNum);
+    if (showHourLeadingZero && hourStr.length === 1) hourStr = '0' + hourStr;
+
+    // Get minute (and optionally second) using Intl for timezone correctness
+    const minuteFormatter = new Intl.DateTimeFormat('en-US', {
       minute: '2-digit',
       second: showSeconds ? '2-digit' : undefined,
-      hour12: use12HourFormat,
       timeZone: timezone
     });
-    
-    const currentTime = timeFormatter.format(currentDate);
+    const parts = minuteFormatter.formatToParts(currentDate);
+    const minutePart = parts.find(p => p.type === 'minute');
+    const minuteStr = (minutePart ? minutePart.value : '').padStart(2, '0');
+    const secondPart = showSeconds ? parts.find(p => p.type === 'second') : null;
+    const secondStr = secondPart ? secondPart.value.padStart(2, '0') : '';
+
+    // Get the time separator from the user's locale
+    const localeFormatter = new Intl.DateTimeFormat(this.config.locale || 'en-US', {
+      hour: 'numeric', minute: 'numeric', hour12: false, timeZone: timezone
+    });
+    const localeParts = localeFormatter.formatToParts(currentDate);
+    const separatorPart = localeParts.find(p => p.type === 'literal');
+    const separator = separatorPart ? separatorPart.value : ':';
+
+    // Get AM/PM period if using 12-hour format
+    let period = '';
+    if (use12HourFormat) {
+      const periodFormatter = new Intl.DateTimeFormat(this.config.locale || 'en-US', {
+        hour: 'numeric', hour12: true, timeZone: timezone
+      });
+      const periodParts = periodFormatter.formatToParts(currentDate);
+      const dayPeriod = periodParts.find(p => p.type === 'dayPeriod');
+      if (dayPeriod) period = '\u202F' + dayPeriod.value;
+    }
+
+    const currentTime = hourStr + separator + minuteStr + (showSeconds ? separator + secondStr : '') + period;
     const currentDayOfWeek = this.getLocalizedDayNameFull(currentDate, timezone);
     const selectedLocale = this.config.locale || this.language || 'en';
     const currentDateFormatted = new Intl.DateTimeFormat(selectedLocale, {
@@ -20368,8 +20439,8 @@ var WeatherChartCard = (function () {
       ${config.show_forecast_toggle ? x`
         <button class="forecast-toggle"
           @click="${this.handleForecastTypeToggle.bind(this)}"
-          ?disabled="${parseInt(config.forecast.auto_rotate, 10) > 0}">
-          ${parseInt(config.forecast.auto_rotate, 10) > 0 ? `Auto [${parseInt(config.forecast.auto_rotate, 10)}]` : (this.config.forecast.type === 'daily' ? 'Hourly' : 'Daily')}
+          ?disabled="${this._canAutoRotate}">
+          ${this._canAutoRotate ? `Auto [${parseInt(config.forecast.auto_rotate, 10)}]` : (this.config.forecast.type === 'daily' ? 'Hourly' : 'Daily')}
         </button>
       ` : ''}
     </div>
@@ -20433,10 +20504,15 @@ var WeatherChartCard = (function () {
     const showDewpoint = config.show_dew_point == true;
     const showWindgustspeed = config.show_wind_gust_speed == true;
     const showVisibility = config.show_visibility == true;
+    const visibilityDisplayUnit = this.unitVisibility || this.visibilitySourceUnit || (this.weather && this.weather.attributes.visibility_unit);
+    let dVisibility = visibility;
+    if (showVisibility && visibility !== undefined) {
+      dVisibility = this.convertVisibility(visibility, this.visibilitySourceUnit, visibilityDisplayUnit);
+    }
 
   return x`
     <div class="attributes">
-      ${((showHumidity && humidity !== undefined) || (showPressure && dPressure !== undefined) || (showDewpoint && dew_point !== undefined) || (showVisibility && visibility !== undefined)) ? x`
+      ${((showHumidity && humidity !== undefined) || (showPressure && dPressure !== undefined) || (showDewpoint && dew_point !== undefined) || (showVisibility && dVisibility !== undefined)) ? x`
         <div>
           ${showHumidity && humidity !== undefined ? x`
             <ha-icon icon="hass:water-percent"></ha-icon> ${humidity} %<br>
@@ -20447,8 +20523,8 @@ var WeatherChartCard = (function () {
           ${showDewpoint && dew_point !== undefined ? x`
             <ha-icon icon="hass:thermometer-water"></ha-icon> ${dDewPoint} ${dewPointDisplayUnit} <br>
           ` : ''}
-          ${showVisibility && visibility !== undefined ? x`
-            <ha-icon icon="hass:eye"></ha-icon> ${visibility} ${this.weather.attributes.visibility_unit}
+          ${showVisibility && dVisibility !== undefined ? x`
+            <ha-icon icon="hass:eye"></ha-icon> ${dVisibility} ${visibilityDisplayUnit}
           ` : ''}
         </div>
       ` : ''}

--- a/dist/weather-chart-card-ha.js
+++ b/dist/weather-chart-card-ha.js
@@ -19368,8 +19368,8 @@ var WeatherChartCard = (function () {
       return numericValue;
     }
     const result = numericValue * fromFactor / toFactor;
-    // Round to 1 decimal if needed, whole number if >= 10
-    return result >= 10 ? Math.round(result) : Math.round(result * 10) / 10;
+    // Round to 1 decimal place; drop the decimal if the result is a whole number
+    return Math.round(result * 10) / 10;
   }
 
   async firstUpdated(changedProperties) {
@@ -20345,44 +20345,34 @@ var WeatherChartCard = (function () {
     const showDate = this.config.show_date;
     const currentDate = new Date();
     
-    // Get hour in the correct timezone
-    const hourIn24 = parseInt(new Intl.DateTimeFormat('en-US', { hour: 'numeric', hour12: false, timeZone: timezone }).format(currentDate));
-    const hourNum = use12HourFormat ? (hourIn24 % 12 || 12) : hourIn24;
-    let hourStr = String(hourNum);
-    if (showHourLeadingZero && hourStr.length === 1) hourStr = '0' + hourStr;
-
-    // Get minute (and optionally second) using Intl for timezone correctness
-    const minuteFormatter = new Intl.DateTimeFormat('en-US', {
+    // Build the full time string using Intl.DateTimeFormat, then fix the hour for leading zero control
+    const locale = this.config.locale || 'en-US';
+    const timeFormatter = new Intl.DateTimeFormat(locale, {
+      hour: '2-digit',
       minute: '2-digit',
       second: showSeconds ? '2-digit' : undefined,
+      hour12: use12HourFormat,
       timeZone: timezone
     });
-    const parts = minuteFormatter.formatToParts(currentDate);
-    const minutePart = parts.find(p => p.type === 'minute');
-    const minuteStr = (minutePart ? minutePart.value : '').padStart(2, '0');
-    const secondPart = showSeconds ? parts.find(p => p.type === 'second') : null;
-    const secondStr = secondPart ? secondPart.value.padStart(2, '0') : '';
+    const parts = timeFormatter.formatToParts(currentDate);
 
-    // Get the time separator from the user's locale
-    const localeFormatter = new Intl.DateTimeFormat(this.config.locale || 'en-US', {
-      hour: 'numeric', minute: 'numeric', hour12: false, timeZone: timezone
-    });
-    const localeParts = localeFormatter.formatToParts(currentDate);
-    const separatorPart = localeParts.find(p => p.type === 'literal');
-    const separator = separatorPart ? separatorPart.value : ':';
-
-    // Get AM/PM period if using 12-hour format
-    let period = '';
-    if (use12HourFormat) {
-      const periodFormatter = new Intl.DateTimeFormat(this.config.locale || 'en-US', {
-        hour: 'numeric', hour12: true, timeZone: timezone
-      });
-      const periodParts = periodFormatter.formatToParts(currentDate);
-      const dayPeriod = periodParts.find(p => p.type === 'dayPeriod');
-      if (dayPeriod) period = '\u202F' + dayPeriod.value;
+    // Rebuild the time string, adjusting the hour part for leading zero preference
+    var currentTime = '';
+    for (var i = 0; i < parts.length; i++) {
+      var part = parts[i];
+      if (part.type === 'hour') {
+        var h = part.value;
+        if (showHourLeadingZero && h.length === 1) {
+          h = '0' + h;
+        } else if (!showHourLeadingZero && h.length === 2 && h[0] === '0') {
+          h = h.slice(1);
+        }
+        currentTime += h;
+      } else {
+        currentTime += part.value;
+      }
     }
 
-    const currentTime = hourStr + separator + minuteStr + (showSeconds ? separator + secondStr : '') + period;
     const currentDayOfWeek = this.getLocalizedDayNameFull(currentDate, timezone);
     const selectedLocale = this.config.locale || this.language || 'en';
     const currentDateFormatted = new Intl.DateTimeFormat(selectedLocale, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-chart-card-ha",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-chart-card-ha",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Enhanced weather chart card with temperature gradients, timezone support, and customizable layouts for Home Assistant",
   "keywords": [
     "home-assistant",

--- a/src/main.js
+++ b/src/main.js
@@ -937,8 +937,8 @@ convertVisibility(value, fromUnit, toUnit) {
     return numericValue;
   }
   const result = numericValue * fromFactor / toFactor;
-  // Round to 1 decimal if needed, whole number if >= 10
-  return result >= 10 ? Math.round(result) : Math.round(result * 10) / 10;
+  // Round to 1 decimal place; drop the decimal if the result is a whole number
+  return Math.round(result * 10) / 10;
 }
 
 async firstUpdated(changedProperties) {
@@ -1914,44 +1914,34 @@ updateClock() {
   const showDate = this.config.show_date;
   const currentDate = new Date();
   
-  // Get hour in the correct timezone
-  const hourIn24 = parseInt(new Intl.DateTimeFormat('en-US', { hour: 'numeric', hour12: false, timeZone: timezone }).format(currentDate));
-  const hourNum = use12HourFormat ? (hourIn24 % 12 || 12) : hourIn24;
-  let hourStr = String(hourNum);
-  if (showHourLeadingZero && hourStr.length === 1) hourStr = '0' + hourStr;
-
-  // Get minute (and optionally second) using Intl for timezone correctness
-  const minuteFormatter = new Intl.DateTimeFormat('en-US', {
+  // Build the full time string using Intl.DateTimeFormat, then fix the hour for leading zero control
+  const locale = this.config.locale || 'en-US';
+  const timeFormatter = new Intl.DateTimeFormat(locale, {
+    hour: '2-digit',
     minute: '2-digit',
     second: showSeconds ? '2-digit' : undefined,
+    hour12: use12HourFormat,
     timeZone: timezone
   });
-  const parts = minuteFormatter.formatToParts(currentDate);
-  const minutePart = parts.find(p => p.type === 'minute');
-  const minuteStr = (minutePart ? minutePart.value : '').padStart(2, '0');
-  const secondPart = showSeconds ? parts.find(p => p.type === 'second') : null;
-  const secondStr = secondPart ? secondPart.value.padStart(2, '0') : '';
+  const parts = timeFormatter.formatToParts(currentDate);
 
-  // Get the time separator from the user's locale
-  const localeFormatter = new Intl.DateTimeFormat(this.config.locale || 'en-US', {
-    hour: 'numeric', minute: 'numeric', hour12: false, timeZone: timezone
-  });
-  const localeParts = localeFormatter.formatToParts(currentDate);
-  const separatorPart = localeParts.find(p => p.type === 'literal');
-  const separator = separatorPart ? separatorPart.value : ':';
-
-  // Get AM/PM period if using 12-hour format
-  let period = '';
-  if (use12HourFormat) {
-    const periodFormatter = new Intl.DateTimeFormat(this.config.locale || 'en-US', {
-      hour: 'numeric', hour12: true, timeZone: timezone
-    });
-    const periodParts = periodFormatter.formatToParts(currentDate);
-    const dayPeriod = periodParts.find(p => p.type === 'dayPeriod');
-    if (dayPeriod) period = '\u202F' + dayPeriod.value;
+  // Rebuild the time string, adjusting the hour part for leading zero preference
+  var currentTime = '';
+  for (var i = 0; i < parts.length; i++) {
+    var part = parts[i];
+    if (part.type === 'hour') {
+      var h = part.value;
+      if (showHourLeadingZero && h.length === 1) {
+        h = '0' + h;
+      } else if (!showHourLeadingZero && h.length === 2 && h[0] === '0') {
+        h = h.slice(1);
+      }
+      currentTime += h;
+    } else {
+      currentTime += part.value;
+    }
   }
 
-  const currentTime = hourStr + separator + minuteStr + (showSeconds ? separator + secondStr : '') + period;
   const currentDayOfWeek = this.getLocalizedDayNameFull(currentDate, timezone);
   const selectedLocale = this.config.locale || this.language || 'en';
   const currentDateFormatted = new Intl.DateTimeFormat(selectedLocale, {

--- a/src/main.js
+++ b/src/main.js
@@ -285,6 +285,13 @@ handleForecastTypeToggle() {
     return (this.weather.attributes.supported_features & feature) !== 0;
   }
 
+  get _canAutoRotate() {
+    const interval = this.config && this.config.forecast ? parseInt(this.config.forecast.auto_rotate, 10) : 0;
+    return interval > 0 && this.weather
+      && this.supportsFeature(WeatherEntityFeature.FORECAST_DAILY)
+      && this.supportsFeature(WeatherEntityFeature.FORECAST_HOURLY);
+  }
+
   constructor() {
     super();
     this.resizeObserver = null;
@@ -303,6 +310,8 @@ handleForecastTypeToggle() {
     this.stopAutoRotate();
     const interval = this.config && this.config.forecast ? parseInt(this.config.forecast.auto_rotate, 10) : 0;
     if (!interval || interval < 1 || interval > 60) return;
+    // Only rotate if the entity supports both daily and hourly forecasts
+    if (!this.weather || !this.supportsFeature(WeatherEntityFeature.FORECAST_DAILY) || !this.supportsFeature(WeatherEntityFeature.FORECAST_HOURLY)) return;
     // Align to the next whole minute, then start the interval
     const now = new Date();
     const msUntilNextMinute = (60 - now.getSeconds()) * 1000 - now.getMilliseconds();
@@ -1918,15 +1927,18 @@ updateClock() {
     timeZone: timezone
   });
   const parts = minuteFormatter.formatToParts(currentDate);
-  const minuteStr = (parts.find(p => p.type === 'minute')?.value || '').padStart(2, '0');
-  const secondStr = showSeconds ? (parts.find(p => p.type === 'second')?.value || '').padStart(2, '0') : '';
+  const minutePart = parts.find(p => p.type === 'minute');
+  const minuteStr = (minutePart ? minutePart.value : '').padStart(2, '0');
+  const secondPart = showSeconds ? parts.find(p => p.type === 'second') : null;
+  const secondStr = secondPart ? secondPart.value.padStart(2, '0') : '';
 
   // Get the time separator from the user's locale
   const localeFormatter = new Intl.DateTimeFormat(this.config.locale || 'en-US', {
     hour: 'numeric', minute: 'numeric', hour12: false, timeZone: timezone
   });
   const localeParts = localeFormatter.formatToParts(currentDate);
-  const separator = localeParts.find(p => p.type === 'literal')?.value || ':';
+  const separatorPart = localeParts.find(p => p.type === 'literal');
+  const separator = separatorPart ? separatorPart.value : ':';
 
   // Get AM/PM period if using 12-hour format
   let period = '';
@@ -1996,8 +2008,8 @@ renderClock({ config } = this) {
       ${config.show_forecast_toggle ? html`
         <button class="forecast-toggle"
           @click="${this.handleForecastTypeToggle.bind(this)}"
-          ?disabled="${parseInt(config.forecast.auto_rotate, 10) > 0}">
-          ${parseInt(config.forecast.auto_rotate, 10) > 0 ? `Auto [${parseInt(config.forecast.auto_rotate, 10)}]` : (this.config.forecast.type === 'daily' ? 'Hourly' : 'Daily')}
+          ?disabled="${this._canAutoRotate}">
+          ${this._canAutoRotate ? `Auto [${parseInt(config.forecast.auto_rotate, 10)}]` : (this.config.forecast.type === 'daily' ? 'Hourly' : 'Daily')}
         </button>
       ` : ''}
     </div>

--- a/src/main.js
+++ b/src/main.js
@@ -191,7 +191,13 @@ set hass(hass) {
     this.windSpeed = this.config.windspeed ? hass.states[this.config.windspeed].state : this.weather.attributes.wind_speed;
     this.dew_point = this.config.dew_point ? hass.states[this.config.dew_point].state : this.weather.attributes.dew_point;
     this.wind_gust_speed = this.config.wind_gust_speed ? hass.states[this.config.wind_gust_speed].state : this.weather.attributes.wind_gust_speed;
-    this.visibility = this.config.visibility ? hass.states[this.config.visibility].state : this.weather.attributes.visibility;
+    if (this.config.visibility && hass.states[this.config.visibility]) {
+      this.visibility = hass.states[this.config.visibility].state;
+      this.visibilitySourceUnit = hass.states[this.config.visibility].attributes.unit_of_measurement || this.weather.attributes.visibility_unit;
+    } else {
+      this.visibility = this.weather.attributes.visibility;
+      this.visibilitySourceUnit = this.weather.attributes.visibility_unit;
+    }
 
     if (this.config.winddir && hass.states[this.config.winddir] && hass.states[this.config.winddir].state !== undefined) {
       this.windDirection = parseFloat(hass.states[this.config.winddir].state);
@@ -904,6 +910,26 @@ convertPrecipitation(value, fromUnit, toUnit) {
   }
 
   return numericValue * fromFactor / toFactor;
+}
+
+convertVisibility(value, fromUnit, toUnit) {
+  const numericValue = Number(value);
+  if (!Number.isFinite(numericValue)) {
+    return value;
+  }
+  if (!fromUnit || !toUnit || fromUnit === toUnit) {
+    return numericValue;
+  }
+  // Normalize to meters first
+  const toMeters = { 'm': 1, 'km': 1000, 'mi': 1609.344, 'yd': 0.9144, 'ft': 0.3048 };
+  const fromFactor = toMeters[fromUnit];
+  const toFactor = toMeters[toUnit];
+  if (!fromFactor || !toFactor) {
+    return numericValue;
+  }
+  const result = numericValue * fromFactor / toFactor;
+  // Round to 1 decimal if needed, whole number if >= 10
+  return result >= 10 ? Math.round(result) : Math.round(result * 10) / 10;
 }
 
 async firstUpdated(changedProperties) {
@@ -1879,16 +1905,41 @@ updateClock() {
   const showDate = this.config.show_date;
   const currentDate = new Date();
   
-  // Force timezone conversion using explicit formatters
-  const timeFormatter = new Intl.DateTimeFormat(this.config.locale || 'en-US', {
-    hour: showHourLeadingZero ? '2-digit' : 'numeric',
+  // Get hour in the correct timezone
+  const hourIn24 = parseInt(new Intl.DateTimeFormat('en-US', { hour: 'numeric', hour12: false, timeZone: timezone }).format(currentDate));
+  const hourNum = use12HourFormat ? (hourIn24 % 12 || 12) : hourIn24;
+  let hourStr = String(hourNum);
+  if (showHourLeadingZero && hourStr.length === 1) hourStr = '0' + hourStr;
+
+  // Get minute (and optionally second) using Intl for timezone correctness
+  const minuteFormatter = new Intl.DateTimeFormat('en-US', {
     minute: '2-digit',
     second: showSeconds ? '2-digit' : undefined,
-    hour12: use12HourFormat,
     timeZone: timezone
   });
-  
-  const currentTime = timeFormatter.format(currentDate);
+  const parts = minuteFormatter.formatToParts(currentDate);
+  const minuteStr = (parts.find(p => p.type === 'minute')?.value || '').padStart(2, '0');
+  const secondStr = showSeconds ? (parts.find(p => p.type === 'second')?.value || '').padStart(2, '0') : '';
+
+  // Get the time separator from the user's locale
+  const localeFormatter = new Intl.DateTimeFormat(this.config.locale || 'en-US', {
+    hour: 'numeric', minute: 'numeric', hour12: false, timeZone: timezone
+  });
+  const localeParts = localeFormatter.formatToParts(currentDate);
+  const separator = localeParts.find(p => p.type === 'literal')?.value || ':';
+
+  // Get AM/PM period if using 12-hour format
+  let period = '';
+  if (use12HourFormat) {
+    const periodFormatter = new Intl.DateTimeFormat(this.config.locale || 'en-US', {
+      hour: 'numeric', hour12: true, timeZone: timezone
+    });
+    const periodParts = periodFormatter.formatToParts(currentDate);
+    const dayPeriod = periodParts.find(p => p.type === 'dayPeriod');
+    if (dayPeriod) period = '\u202F' + dayPeriod.value;
+  }
+
+  const currentTime = hourStr + separator + minuteStr + (showSeconds ? separator + secondStr : '') + period;
   const currentDayOfWeek = this.getLocalizedDayNameFull(currentDate, timezone);
   const selectedLocale = this.config.locale || this.language || 'en';
   const currentDateFormatted = new Intl.DateTimeFormat(selectedLocale, {
@@ -2010,10 +2061,15 @@ renderAttributes({ config, humidity, pressure, windSpeed, windDirection, sun, la
   const showDewpoint = config.show_dew_point == true;
   const showWindgustspeed = config.show_wind_gust_speed == true;
   const showVisibility = config.show_visibility == true;
+  const visibilityDisplayUnit = this.unitVisibility || this.visibilitySourceUnit || (this.weather && this.weather.attributes.visibility_unit);
+  let dVisibility = visibility;
+  if (showVisibility && visibility !== undefined) {
+    dVisibility = this.convertVisibility(visibility, this.visibilitySourceUnit, visibilityDisplayUnit);
+  }
 
 return html`
     <div class="attributes">
-      ${((showHumidity && humidity !== undefined) || (showPressure && dPressure !== undefined) || (showDewpoint && dew_point !== undefined) || (showVisibility && visibility !== undefined)) ? html`
+      ${((showHumidity && humidity !== undefined) || (showPressure && dPressure !== undefined) || (showDewpoint && dew_point !== undefined) || (showVisibility && dVisibility !== undefined)) ? html`
         <div>
           ${showHumidity && humidity !== undefined ? html`
             <ha-icon icon="hass:water-percent"></ha-icon> ${humidity} %<br>
@@ -2024,8 +2080,8 @@ return html`
           ${showDewpoint && dew_point !== undefined ? html`
             <ha-icon icon="hass:thermometer-water"></ha-icon> ${dDewPoint} ${dewPointDisplayUnit} <br>
           ` : ''}
-          ${showVisibility && visibility !== undefined ? html`
-            <ha-icon icon="hass:eye"></ha-icon> ${visibility} ${this.weather.attributes.visibility_unit}
+          ${showVisibility && dVisibility !== undefined ? html`
+            <ha-icon icon="hass:eye"></ha-icon> ${dVisibility} ${visibilityDisplayUnit}
           ` : ''}
         </div>
       ` : ''}

--- a/src/weather-chart-card-editor.js
+++ b/src/weather-chart-card-editor.js
@@ -259,7 +259,6 @@ class WeatherChartCardEditor extends LitElement {
     delete newConfig.sun_latitude;
     delete newConfig.sun_longitude;
     delete newConfig.sun_timezone;
-    delete newConfig.timezone;
     this._cityInput = '';
     this._geoStatus = '';
     this.configChanged(newConfig);
@@ -397,6 +396,7 @@ class WeatherChartCardEditor extends LitElement {
       <div class="textfield-container">
 <label class="switch-label">Entity</label>
 <select
+  aria-label="Entity"
   style="width: 100%; padding: 8px; margin-bottom: 8px; border: 1px solid var(--divider-color, #ccc); border-radius: 4px; background: var(--card-background-color, #fff); color: var(--primary-text-color, #000); font-size: 14px;"
   .value=${this._entity}
   @change=${(e) => this._EntityChanged(e, 'entity')}
@@ -413,6 +413,7 @@ class WeatherChartCardEditor extends LitElement {
       <div>
         <label>Select custom language</label>
         <select
+          aria-label="Select custom language"
           style="width: 100%; padding: 8px; margin: 10px 0; font-size: 14px; border: 1px solid var(--divider-color); border-radius: 4px; background: var(--card-background-color); color: var(--primary-text-color);"
           .value=${this._config.locale || ''}
           @change=${(e) => {
@@ -914,6 +915,7 @@ class WeatherChartCardEditor extends LitElement {
           <div>
             <label>Precipitation Type (Probability if supported by the weather entity)</label>
             <select
+              aria-label="Precipitation Type"
               style="width: 100%; padding: 8px; margin: 10px 0; font-size: 14px; border: 1px solid var(--divider-color); border-radius: 4px; background: var(--card-background-color); color: var(--primary-text-color);"
               .value=${forecastConfig.precipitation_type || 'rainfall'}
               @change=${(e) => {
@@ -978,6 +980,7 @@ class WeatherChartCardEditor extends LitElement {
                 <span class="experimental-badge" ?hidden=${(forecastConfig.gradient_mode || 'classic') !== 'adaptive'}>Experimental</span>
               </div>
               <select
+                aria-label="Temperature Gradient Mode"
                 style="width: 100%; padding: 8px; margin: 10px 0; font-size: 14px; border: 1px solid var(--divider-color); border-radius: 4px; background: var(--card-background-color); color: var(--primary-text-color);"
                 .value=${forecastConfig.gradient_mode || 'classic'}
                 @change=${(e) => {
@@ -993,6 +996,7 @@ class WeatherChartCardEditor extends LitElement {
             <div ?hidden=${(forecastConfig.gradient_mode || 'classic') === 'classic'}>
               <label>Climate Preset Range</label>
               <select
+                aria-label="Climate Preset Range"
                 style="width: 100%; padding: 8px; margin: 10px 0; font-size: 14px; border: 1px solid var(--divider-color); border-radius: 4px; background: var(--card-background-color); color: var(--primary-text-color);"
                 .value=${forecastConfig.gradient_preset || 'temperate'}
                 @change=${(e) => {
@@ -1019,6 +1023,7 @@ class WeatherChartCardEditor extends LitElement {
             <div>
               <label>Convert temperature to</label>
               <select
+                aria-label="Convert temperature to"
                 style="width: 100%; padding: 8px; margin: 10px 0; font-size: 14px; border: 1px solid var(--divider-color); border-radius: 4px; background: var(--card-background-color); color: var(--primary-text-color);"
                 .value=${unitsConfig.temperature || ''}
                 @change=${(e) => {
@@ -1034,6 +1039,7 @@ class WeatherChartCardEditor extends LitElement {
             <div>
               <label>Convert pressure to</label>
               <select
+                aria-label="Convert pressure to"
                 style="width: 100%; padding: 8px; margin: 10px 0; font-size: 14px; border: 1px solid var(--divider-color); border-radius: 4px; background: var(--card-background-color); color: var(--primary-text-color);"
                 .value=${unitsConfig.pressure || ''}
                 @change=${(e) => {
@@ -1050,6 +1056,7 @@ class WeatherChartCardEditor extends LitElement {
             <div>
               <label>Convert wind speed to</label>
               <select
+                aria-label="Convert wind speed to"
                 style="width: 100%; padding: 8px; margin: 10px 0; font-size: 14px; border: 1px solid var(--divider-color); border-radius: 4px; background: var(--card-background-color); color: var(--primary-text-color);"
                 .value=${unitsConfig.speed || ''}
                 @change=${(e) => {
@@ -1068,6 +1075,7 @@ class WeatherChartCardEditor extends LitElement {
             <div>
               <label>Display precipitation unit</label>
               <select
+                aria-label="Display precipitation unit"
                 style="width: 100%; padding: 8px; margin: 10px 0; font-size: 14px; border: 1px solid var(--divider-color); border-radius: 4px; background: var(--card-background-color); color: var(--primary-text-color);"
                 .value=${unitsConfig.precipitation || ''}
                 @change=${(e) => {


### PR DESCRIPTION
Fix visibility sensor: guard null access, add unit conversion, display correct unit

- Guard access to custom visibility sensor entity to prevent crash on reload
- Add convertVisibility() method to handle m/km/mi/yd/ft conversions
- Read unit_of_measurement from sensor attributes (e.g. OpenWeatherMap reports 'm')
- Convert visibility value to target display unit (e.g. 10000 m → 10 km)
- Use correct display unit in renderAttributes instead of hardcoded weather entity unit

Fix clear-city deleting general timezone, add aria-labels to selects, guard auto-rotate

- _clearCity() no longer deletes config.timezone (general override),
  only removes sun-specific fields (sun_city, sun_latitude, sun_longitude, sun_timezone)
- Add aria-label to all 9 native <select> elements in the editor
  for assistive technology accessibility
- Auto-rotate now verifies the weather entity supports both daily and
  hourly forecasts before starting the timer; toggle button reflects
  actual capability instead of just checking the interval value

Fixes #25