### PR TITLE
Use localized short weekday labels

### DIFF
--- a/dist/weather-chart-card-ha.js
+++ b/dist/weather-chart-card-ha.js
@@ -18911,35 +18911,45 @@ var WeatherChartCard = (function () {
     return null;
   }
 
+  formatLocalizedShortDateLabel(label, locale) {
+    const normalizedLabel = label.replace(/[.\s]+$/u, '');
+    return WeatherChartCard.LATIN_SCRIPT_REGEX.test(normalizedLabel)
+      ? normalizedLabel.toLocaleUpperCase(locale)
+      : normalizedLabel;
+  }
+
   getLocalizedDayName(date, timezone) {
     const dayIndex = date.getDay(); // 0 = Sunday, 1 = Monday, etc.
     
-    // Priority 1: Try translation array from locale.js
-    const days = this.getLocaleArray('days');
-    if (days && days[dayIndex] && typeof days[dayIndex] === 'string' && days[dayIndex].length > 0) {
-      const dayName = days[dayIndex].substring(0, 3);
-      // Only uppercase for Latin-script languages
-      return WeatherChartCard.LATIN_SCRIPT_REGEX.test(dayName) ? dayName.toUpperCase() : dayName;
+    // Priority 1: Try dedicated short day translation array from locale.js
+    const shortDays = this.getLocaleArray('days_short');
+    if (shortDays && shortDays[dayIndex] && typeof shortDays[dayIndex] === 'string' && shortDays[dayIndex].length > 0) {
+      return this.formatLocalizedShortDateLabel(shortDays[dayIndex], this.config.locale || this.language || 'en');
     }
     
-    // Priority 2: Browser Intl fallback
+    // Priority 2: Browser Intl localized short weekday name
     try {
       const selectedLocale = this.config.locale || this.language || 'en';
       const dayFormatter = new Intl.DateTimeFormat(selectedLocale, {
-        weekday: 'long',
+        weekday: 'short',
         timeZone: timezone
       });
       const formatted = dayFormatter.format(date);
       if (formatted && formatted.length > 0) {
-        const dayName = formatted.substring(0, 3);
-        // Only uppercase for Latin-script languages
-        return WeatherChartCard.LATIN_SCRIPT_REGEX.test(dayName) ? dayName.toUpperCase() : dayName;
+        return this.formatLocalizedShortDateLabel(formatted, selectedLocale);
       }
     } catch (e) {
-      // Intl failed, continue to ultimate fallback
+      // Intl failed, continue to translation-array fallback
+    }
+
+    // Priority 3: Try full day translation array from locale.js
+    const days = this.getLocaleArray('days');
+    if (days && days[dayIndex] && typeof days[dayIndex] === 'string' && days[dayIndex].length > 0) {
+      const dayName = days[dayIndex].substring(0, 3);
+      return this.formatLocalizedShortDateLabel(dayName, this.config.locale || this.language || 'en');
     }
     
-    // Priority 3: Hardcoded English fallback
+    // Priority 4: Hardcoded English fallback
     const englishDays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
     return englishDays[dayIndex].substring(0, 3).toUpperCase();
   }
@@ -20763,7 +20773,7 @@ var WeatherChartCard = (function () {
   }
 
   // Regex to detect Latin script characters for uppercase formatting (ES2019 compatible)
-  WeatherChartCard.LATIN_SCRIPT_REGEX = /^[A-Za-z]+$/;
+  WeatherChartCard.LATIN_SCRIPT_REGEX = /^\p{Script=Latin}+$/u;
 
   if (!customElements.get('weather-chart-card-ha')) {
     customElements.define('weather-chart-card-ha', WeatherChartCard);

--- a/dist/weather-chart-card-ha.js
+++ b/dist/weather-chart-card-ha.js
@@ -18921,13 +18921,7 @@ var WeatherChartCard = (function () {
   getLocalizedDayName(date, timezone) {
     const dayIndex = date.getDay(); // 0 = Sunday, 1 = Monday, etc.
     
-    // Priority 1: Try dedicated short day translation array from locale.js
-    const shortDays = this.getLocaleArray('days_short');
-    if (shortDays && shortDays[dayIndex] && typeof shortDays[dayIndex] === 'string' && shortDays[dayIndex].length > 0) {
-      return this.formatLocalizedShortDateLabel(shortDays[dayIndex], this.config.locale || this.language || 'en');
-    }
-    
-    // Priority 2: Browser Intl localized short weekday name
+    // Priority 1: Browser Intl localized short weekday name
     try {
       const selectedLocale = this.config.locale || this.language || 'en';
       const dayFormatter = new Intl.DateTimeFormat(selectedLocale, {
@@ -18942,14 +18936,14 @@ var WeatherChartCard = (function () {
       // Intl failed, continue to translation-array fallback
     }
 
-    // Priority 3: Try full day translation array from locale.js
+    // Priority 2: Try full day translation array from locale.js
     const days = this.getLocaleArray('days');
     if (days && days[dayIndex] && typeof days[dayIndex] === 'string' && days[dayIndex].length > 0) {
       const dayName = days[dayIndex].substring(0, 3);
       return this.formatLocalizedShortDateLabel(dayName, this.config.locale || this.language || 'en');
     }
     
-    // Priority 4: Hardcoded English fallback
+    // Priority 3: Hardcoded English fallback
     const englishDays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
     return englishDays[dayIndex].substring(0, 3).toUpperCase();
   }

--- a/src/main.js
+++ b/src/main.js
@@ -480,35 +480,45 @@ getLocaleArray(key) {
   return null;
 }
 
+formatLocalizedShortDateLabel(label, locale) {
+  const normalizedLabel = label.replace(/[.\s]+$/u, '');
+  return WeatherChartCard.LATIN_SCRIPT_REGEX.test(normalizedLabel)
+    ? normalizedLabel.toLocaleUpperCase(locale)
+    : normalizedLabel;
+}
+
 getLocalizedDayName(date, timezone) {
   const dayIndex = date.getDay(); // 0 = Sunday, 1 = Monday, etc.
   
-  // Priority 1: Try translation array from locale.js
-  const days = this.getLocaleArray('days');
-  if (days && days[dayIndex] && typeof days[dayIndex] === 'string' && days[dayIndex].length > 0) {
-    const dayName = days[dayIndex].substring(0, 3);
-    // Only uppercase for Latin-script languages
-    return WeatherChartCard.LATIN_SCRIPT_REGEX.test(dayName) ? dayName.toUpperCase() : dayName;
+  // Priority 1: Try dedicated short day translation array from locale.js
+  const shortDays = this.getLocaleArray('days_short');
+  if (shortDays && shortDays[dayIndex] && typeof shortDays[dayIndex] === 'string' && shortDays[dayIndex].length > 0) {
+    return this.formatLocalizedShortDateLabel(shortDays[dayIndex], this.config.locale || this.language || 'en');
   }
   
-  // Priority 2: Browser Intl fallback
+  // Priority 2: Browser Intl localized short weekday name
   try {
     const selectedLocale = this.config.locale || this.language || 'en';
     const dayFormatter = new Intl.DateTimeFormat(selectedLocale, {
-      weekday: 'long',
+      weekday: 'short',
       timeZone: timezone
     });
     const formatted = dayFormatter.format(date);
     if (formatted && formatted.length > 0) {
-      const dayName = formatted.substring(0, 3);
-      // Only uppercase for Latin-script languages
-      return WeatherChartCard.LATIN_SCRIPT_REGEX.test(dayName) ? dayName.toUpperCase() : dayName;
+      return this.formatLocalizedShortDateLabel(formatted, selectedLocale);
     }
   } catch (e) {
-    // Intl failed, continue to ultimate fallback
+    // Intl failed, continue to translation-array fallback
+  }
+
+  // Priority 3: Try full day translation array from locale.js
+  const days = this.getLocaleArray('days');
+  if (days && days[dayIndex] && typeof days[dayIndex] === 'string' && days[dayIndex].length > 0) {
+    const dayName = days[dayIndex].substring(0, 3);
+    return this.formatLocalizedShortDateLabel(dayName, this.config.locale || this.language || 'en');
   }
   
-  // Priority 3: Hardcoded English fallback
+  // Priority 4: Hardcoded English fallback
   const englishDays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
   return englishDays[dayIndex].substring(0, 3).toUpperCase();
 }
@@ -2332,7 +2342,7 @@ renderLastUpdated() {
 }
 
 // Regex to detect Latin script characters for uppercase formatting (ES2019 compatible)
-WeatherChartCard.LATIN_SCRIPT_REGEX = /^[A-Za-z]+$/;
+WeatherChartCard.LATIN_SCRIPT_REGEX = /^\p{Script=Latin}+$/u;
 
 export default WeatherChartCard;
 

--- a/src/main.js
+++ b/src/main.js
@@ -490,13 +490,7 @@ formatLocalizedShortDateLabel(label, locale) {
 getLocalizedDayName(date, timezone) {
   const dayIndex = date.getDay(); // 0 = Sunday, 1 = Monday, etc.
   
-  // Priority 1: Try dedicated short day translation array from locale.js
-  const shortDays = this.getLocaleArray('days_short');
-  if (shortDays && shortDays[dayIndex] && typeof shortDays[dayIndex] === 'string' && shortDays[dayIndex].length > 0) {
-    return this.formatLocalizedShortDateLabel(shortDays[dayIndex], this.config.locale || this.language || 'en');
-  }
-  
-  // Priority 2: Browser Intl localized short weekday name
+  // Priority 1: Browser Intl localized short weekday name
   try {
     const selectedLocale = this.config.locale || this.language || 'en';
     const dayFormatter = new Intl.DateTimeFormat(selectedLocale, {
@@ -511,14 +505,14 @@ getLocalizedDayName(date, timezone) {
     // Intl failed, continue to translation-array fallback
   }
 
-  // Priority 3: Try full day translation array from locale.js
+  // Priority 2: Try full day translation array from locale.js
   const days = this.getLocaleArray('days');
   if (days && days[dayIndex] && typeof days[dayIndex] === 'string' && days[dayIndex].length > 0) {
     const dayName = days[dayIndex].substring(0, 3);
     return this.formatLocalizedShortDateLabel(dayName, this.config.locale || this.language || 'en');
   }
   
-  // Priority 4: Hardcoded English fallback
+  // Priority 3: Hardcoded English fallback
   const englishDays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
   return englishDays[dayIndex].substring(0, 3).toUpperCase();
 }

--- a/src/main.js
+++ b/src/main.js
@@ -482,9 +482,12 @@ getLocaleArray(key) {
 
 formatLocalizedShortDateLabel(label, locale) {
   const normalizedLabel = label.replace(/[.\s]+$/u, '');
-  return WeatherChartCard.LATIN_SCRIPT_REGEX.test(normalizedLabel)
-    ? normalizedLabel.toLocaleUpperCase(locale)
-    : normalizedLabel;
+  if (!WeatherChartCard.LATIN_SCRIPT_REGEX.test(normalizedLabel)) return normalizedLabel;
+  try {
+    return normalizedLabel.toLocaleUpperCase(locale);
+  } catch (e) {
+    return normalizedLabel.toUpperCase();
+  }
 }
 
 getLocalizedDayName(date, timezone) {


### PR DESCRIPTION
## Summary

This changes forecast weekday labels to use localized short weekday names instead of taking the first three characters from the full translated weekday name.

Previously, getLocalizedDayName() used the full weekday translation from locale.js and shortened it with substring(0, 3). That works for English, but produces incorrect or unnatural labels in several languages.

For example, German displayed:

- MON, DIE, MIT

Instead of the expected localized short labels:

- MO, DI, MI

The new logic uses Intl.DateTimeFormat(locale, { weekday: 'short' }) first, while keeping the existing translation-array fallback.

## Examples of improved locales

This improves weekday labels for languages where the short weekday form is not simply the first three letters of the full weekday name, including:

- German: `SO MO DI MI DO FR SA`
- Dutch: `ZO MA DI WO DO VR ZA`
- Finnish: `SU MA TI KE TO PE LA`
- Czech: `NE PO ÚT ST ČT PÁ SO`
- Slovak: `NE PO UT ST ŠT PI SO`
- Lithuanian: `SK PR AN TR KT PN ŠT`
- Korean: `일 월 화 수 목 금 토`

English remains unchanged:

- SUN MON TUE WED THU FRI SAT

## Implementation notes

- Adds a helper to normalize localized short date labels.
- Removes trailing dots from browser-provided short labels, e.g. French dim. becomes DIM.
- Keeps uppercase formatting for Latin-script labels.
- Extends Latin-script detection to accented Latin characters so labels like ÃšT, ÄŒT, PÃ, MIÃ‰ are handled correctly.
- Keeps the existing hardcoded English fallback.

## Testing

- Ran ESLint successfully.
- Ran Rollup build successfully.
- Verified generated labels for German, Dutch, Finnish, Czech, Slovak, Lithuanian, Korean and English.
- Tested locally in Home Assistant with the HACS resource.